### PR TITLE
Fix macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ source .venv/bin/activate
 uv sync
 ```
 
-### 4. Configure Claude for Desktop
+### 4. macOS Compatibility (Optional)
+
+If you're running on macOS, you may need to apply a compatibility patch for the `multiconn_archicad` library:
+
+```bash
+# Run the macOS compatibility patch
+python scripts/apply_macos_patch.py
+```
+
+This patch allows the server to work on macOS by providing dummy implementations for Windows-specific UI automation features.
+
+### 5. Configure Claude for Desktop
 
 Finally, tell Claude how to run your server. Open your `claude_desktop_config.json` file and add the following configuration.
 

--- a/patches/macos_compatibility.patch
+++ b/patches/macos_compatibility.patch
@@ -1,0 +1,30 @@
+import sys
+from .dialog_handler_base import UnhandledDialogError, DialogHandlerBase, EmptyDialogHandler
+
+# Platform-specific imports
+if sys.platform == "win32":
+    from .win_dialog_handler import WinDialogHandler
+    from .win_int_handler_factory import win_int_handler_factory
+    __all__: tuple[str, ...] = (
+        "WinDialogHandler",
+        "win_int_handler_factory",
+        "UnhandledDialogError",
+        "DialogHandlerBase",
+        "EmptyDialogHandler",
+    )
+else:
+    # On non-Windows platforms, create dummy classes
+    class WinDialogHandler(DialogHandlerBase):
+        def __init__(self, *args, **kwargs):
+            raise NotImplementedError("WinDialogHandler is not available on non-Windows platforms")
+    
+    def win_int_handler_factory(*args, **kwargs):
+        raise NotImplementedError("win_int_handler_factory is not available on non-Windows platforms")
+    
+    __all__: tuple[str, ...] = (
+        "WinDialogHandler",
+        "win_int_handler_factory",
+        "UnhandledDialogError",
+        "DialogHandlerBase",
+        "EmptyDialogHandler",
+    ) 

--- a/scripts/apply_macos_patch.py
+++ b/scripts/apply_macos_patch.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Script to apply macOS compatibility patch for multiconn_archicad library.
+This patch allows the library to work on non-Windows platforms by providing
+dummy implementations for Windows-specific features.
+"""
+
+import os
+import sys
+import shutil
+from pathlib import Path
+
+
+def find_multiconn_archicad_path():
+    """Find the path to the multiconn_archicad package."""
+    try:
+        import multiconn_archicad
+        return Path(multiconn_archicad.__file__).parent
+    except ImportError:
+        print("Error: multiconn_archicad not found. Please install it first.")
+        return None
+
+
+def apply_patch():
+    """Apply the macOS compatibility patch."""
+    if sys.platform == "win32":
+        print("Windows detected - no patch needed.")
+        return True
+    
+    print("Non-Windows platform detected - applying compatibility patch...")
+    
+    # Find the multiconn_archicad package
+    package_path = find_multiconn_archicad_path()
+    if not package_path:
+        return False
+    
+    dialog_handlers_path = package_path / "dialog_handlers" / "__init__.py"
+    
+    if not dialog_handlers_path.exists():
+        print(f"Error: {dialog_handlers_path} not found.")
+        return False
+    
+    # Create the patched content
+    patched_content = '''import sys
+from .dialog_handler_base import UnhandledDialogError, DialogHandlerBase, EmptyDialogHandler
+
+# Platform-specific imports
+if sys.platform == "win32":
+    from .win_dialog_handler import WinDialogHandler
+    from .win_int_handler_factory import win_int_handler_factory
+    __all__: tuple[str, ...] = (
+        "WinDialogHandler",
+        "win_int_handler_factory",
+        "UnhandledDialogError",
+        "DialogHandlerBase",
+        "EmptyDialogHandler",
+    )
+else:
+    # On non-Windows platforms, create dummy classes
+    class WinDialogHandler(DialogHandlerBase):
+        def __init__(self, *args, **kwargs):
+            raise NotImplementedError("WinDialogHandler is not available on non-Windows platforms")
+    
+    def win_int_handler_factory(*args, **kwargs):
+        raise NotImplementedError("win_int_handler_factory is not available on non-Windows platforms")
+    
+    __all__: tuple[str, ...] = (
+        "WinDialogHandler",
+        "win_int_handler_factory",
+        "UnhandledDialogError",
+        "DialogHandlerBase",
+        "EmptyDialogHandler",
+    )
+'''
+    
+    # Backup the original file
+    backup_path = dialog_handlers_path.with_suffix('.py.bak')
+    shutil.copy2(dialog_handlers_path, backup_path)
+    print(f"Backed up original file to: {backup_path}")
+    
+    # Write the patched content
+    dialog_handlers_path.write_text(patched_content)
+    print(f"Applied patch to: {dialog_handlers_path}")
+    
+    return True
+
+
+if __name__ == "__main__":
+    success = apply_patch()
+    if success:
+        print("✅ macOS compatibility patch applied successfully!")
+    else:
+        print("❌ Failed to apply patch.")
+        sys.exit(1) 


### PR DESCRIPTION
## Fix macOS compatibility (restore intended functionality)

This PR fixes a bug that prevented the Archicad Tapir MCP server from working on macOS, despite the project being designed for cross-platform use.

### 🐛 Problem
The project was designed for cross-platform use (README mentions macOS paths), but the `multiconn_archicad` dependency introduced Windows-specific imports that weren't properly abstracted, causing import failures on macOS.

### ✅ Fix
- Add platform-specific import handling
- Provide graceful fallbacks for Windows-specific features
- Restore the intended cross-platform functionality

### �� Result
The project now works on macOS as originally intended, matching the cross-platform design described in the README.