### PR TITLE
Configure dual logging

### DIFF
--- a/src/tapir_archicad_mcp/logging_config.py
+++ b/src/tapir_archicad_mcp/logging_config.py
@@ -1,0 +1,42 @@
+import logging
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+LOG_DIR = Path.home() / ".tapir_mcp" / "logs"
+LOG_FILE = LOG_DIR / "tapir_mcp_server.log"
+
+
+def setup_logging():
+    """
+    Configures the root logger to output to both the console and a rotating file.
+    This should be called once at the beginning of the application's lifecycle.
+    """
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    log_formatter = logging.Formatter(
+        '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    # --- File Handler ---
+    file_handler = RotatingFileHandler(
+        LOG_FILE,
+        maxBytes=5 * 1024 * 1024,  # 5 MB
+        backupCount=5
+    )
+    file_handler.setFormatter(log_formatter)
+
+    # --- Console Handler ---
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(log_formatter)
+
+    if root_logger.hasHandlers():
+        root_logger.handlers.clear()
+
+    root_logger.addHandler(file_handler)
+    root_logger.addHandler(console_handler)
+
+    logging.info(f"Logging initialized. Persistent logs will be stored in: {LOG_FILE}")

--- a/src/tapir_archicad_mcp/logging_config.py
+++ b/src/tapir_archicad_mcp/logging_config.py
@@ -7,6 +7,14 @@ LOG_DIR = Path.home() / ".tapir_mcp" / "logs"
 LOG_FILE = LOG_DIR / "tapir_mcp_server.log"
 
 
+def set_debug_lvl_for_modules() -> None:
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("mcp").setLevel(logging.WARNING)
+    logging.getLogger("multiconn_archicad").setLevel(logging.INFO)
+    logging.getLogger("faiss").setLevel(logging.INFO)
+    logging.getLogger("sentence_transformers").setLevel(logging.INFO)
+
+
 def setup_logging():
     """
     Configures the root logger to output to both the console and a rotating file.
@@ -20,17 +28,19 @@ def setup_logging():
 
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
+    set_debug_lvl_for_modules()
 
     # --- File Handler ---
     file_handler = RotatingFileHandler(
         LOG_FILE,
         maxBytes=5 * 1024 * 1024,  # 5 MB
-        backupCount=5
+        backupCount=5,
+        encoding='utf-8'
     )
     file_handler.setFormatter(log_formatter)
 
     # --- Console Handler ---
-    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler = logging.StreamHandler(sys.stderr)
     console_handler.setFormatter(log_formatter)
 
     if root_logger.hasHandlers():

--- a/src/tapir_archicad_mcp/server.py
+++ b/src/tapir_archicad_mcp/server.py
@@ -1,8 +1,9 @@
 import logging
 
 from tapir_archicad_mcp.app import mcp
+from tapir_archicad_mcp.logging_config import setup_logging
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+setup_logging()
 
 
 def main():

--- a/src/tapir_archicad_mcp/tools/search_index.py
+++ b/src/tapir_archicad_mcp/tools/search_index.py
@@ -114,8 +114,8 @@ def _calculate_top_score_relative_threshold(scores: List[float]) -> float:
 
     final_threshold = max(relative_threshold, MIN_ABSOLUTE_THRESHOLD)
 
-    log.debug(f"Search scores: {[f'{s:.2f}' for s in scores]}")
-    log.debug(
+    log.info(f"Search scores: {[f'{s:.2f}' for s in scores]}")
+    log.info(
         f"Best score: {best_score:.2f}, RelativeThreshold: {relative_threshold:.2f}, FinalThreshold: {final_threshold:.2f}")
     return final_threshold
 


### PR DESCRIPTION
 Implements a dual-logging system that writes to both the console (stderr) and a persistent, rotating log file in ~/.tapir_mcp/logs, ensuring logs are always available regardless of the MCP client's behavior.