### PR TITLE
feat: Add 7 new Tapir tools and update to Tapir 1.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tapir-archicad-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "An MCP server that enables AI agents to automate Archicad using natural language via intelligent, semantic tool discovery."
 readme = "README.md"
 authors = [
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "faiss-cpu>=1.12.0",
     "fastmcp>=2.10.5",
-    "multiconn-archicad>=0.4.1",
+    "multiconn-archicad>=0.5.1",
     "sentence-transformers>=5.1.0",
 ]
 

--- a/src/tapir_archicad_mcp/tools/generated/tapir/attribute_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/attribute_commands.py
@@ -13,12 +13,18 @@ from multiconn_archicad.models.tapir.commands import (
 CreateBuildingMaterialsResult,
 CreateCompositesParameters,
 CreateCompositesResult,
+CreateLayerCombinationsParameters,
+CreateLayerCombinationsResult,
 CreateLayersParameters,
 CreateLayersResult,
+CreateSurfacesParameters,
+CreateSurfacesResult,
 GetAttributesByTypeParameters,
 GetAttributesByTypeResult,
 GetBuildingMaterialPhysicalPropertiesParameters,
-GetBuildingMaterialPhysicalPropertiesResult
+GetBuildingMaterialPhysicalPropertiesResult,
+GetLayerCombinationsParameters,
+GetLayerCombinationsResult
 )
 
 
@@ -26,7 +32,7 @@ log = logging.getLogger()
 
 def create_building_materials(port: int, params: CreateBuildingMaterialsParameters) -> CreateBuildingMaterialsResult:
     """
-    Creates Building Material attributes based on the given parameters.
+    Creates or overwrites Building Material attributes based on the given parameters.
     """
     multi_conn = multi_conn_instance.get()
     target_port = Port(port)
@@ -53,7 +59,7 @@ register_tool_for_dispatch(
     create_building_materials,
     name="attributes_create_building_materials",
     title="CreateBuildingMaterials",
-    description="Creates Building Material attributes based on the given parameters.",
+    description="Creates or overwrites Building Material attributes based on the given parameters.",
     params_model=CreateBuildingMaterialsParameters,
     result_model=CreateBuildingMaterialsResult
 )
@@ -61,7 +67,7 @@ register_tool_for_dispatch(
 
 def create_composites(port: int, params: CreateCompositesParameters) -> CreateCompositesResult:
     """
-    Creates Composite attributes based on the given parameters.
+    Creates or overwrites Composite attributes based on the given parameters.
     """
     multi_conn = multi_conn_instance.get()
     target_port = Port(port)
@@ -88,15 +94,50 @@ register_tool_for_dispatch(
     create_composites,
     name="attributes_create_composites",
     title="CreateComposites",
-    description="Creates Composite attributes based on the given parameters.",
+    description="Creates or overwrites Composite attributes based on the given parameters.",
     params_model=CreateCompositesParameters,
     result_model=CreateCompositesResult
 )
 
 
+def create_layer_combinations(port: int, params: CreateLayerCombinationsParameters) -> CreateLayerCombinationsResult:
+    """
+    Creates or overwrites Layer Combination attributes based on the given parameters.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="CreateLayerCombinations",
+            parameters=params.model_dump(mode='json')
+        )
+        return CreateLayerCombinationsResult.model_validate(result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for CreateLayerCombinations result: {e}")
+        raise ValueError(f"Received an invalid response from the Archicad API: {e}")
+    except Exception as e:
+        log.error(f"Error executing CreateLayerCombinations on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    create_layer_combinations,
+    name="attributes_create_layer_combinations",
+    title="CreateLayerCombinations",
+    description="Creates or overwrites Layer Combination attributes based on the given parameters.",
+    params_model=CreateLayerCombinationsParameters,
+    result_model=CreateLayerCombinationsResult
+)
+
+
 def create_layers(port: int, params: CreateLayersParameters) -> CreateLayersResult:
     """
-    Creates Layer attributes based on the given parameters.
+    Creates or overwrites Layer attributes based on the given parameters.
     """
     multi_conn = multi_conn_instance.get()
     target_port = Port(port)
@@ -123,9 +164,44 @@ register_tool_for_dispatch(
     create_layers,
     name="attributes_create_layers",
     title="CreateLayers",
-    description="Creates Layer attributes based on the given parameters.",
+    description="Creates or overwrites Layer attributes based on the given parameters.",
     params_model=CreateLayersParameters,
     result_model=CreateLayersResult
+)
+
+
+def create_surfaces(port: int, params: CreateSurfacesParameters) -> CreateSurfacesResult:
+    """
+    Creates or overwrites Surface attributes based on the given parameters.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="CreateSurfaces",
+            parameters=params.model_dump(mode='json')
+        )
+        return CreateSurfacesResult.model_validate(result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for CreateSurfaces result: {e}")
+        raise ValueError(f"Received an invalid response from the Archicad API: {e}")
+    except Exception as e:
+        log.error(f"Error executing CreateSurfaces on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    create_surfaces,
+    name="attributes_create_surfaces",
+    title="CreateSurfaces",
+    description="Creates or overwrites Surface attributes based on the given parameters.",
+    params_model=CreateSurfacesParameters,
+    result_model=CreateSurfacesResult
 )
 
 
@@ -225,4 +301,39 @@ register_tool_for_dispatch(
     description="Retrieves the physical properties of the given Building Materials.",
     params_model=GetBuildingMaterialPhysicalPropertiesParameters,
     result_model=GetBuildingMaterialPhysicalPropertiesResult
+)
+
+
+def get_layer_combinations(port: int, params: GetLayerCombinationsParameters) -> GetLayerCombinationsResult:
+    """
+    Returns the details of layer combination attributes.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="GetLayerCombinations",
+            parameters=params.model_dump(mode='json')
+        )
+        return GetLayerCombinationsResult.model_validate(result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for GetLayerCombinations result: {e}")
+        raise ValueError(f"Received an invalid response from the Archicad API: {e}")
+    except Exception as e:
+        log.error(f"Error executing GetLayerCombinations on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    get_layer_combinations,
+    name="attributes_get_layer_combinations",
+    title="GetLayerCombinations",
+    description="Returns the details of layer combination attributes.",
+    params_model=GetLayerCombinationsParameters,
+    result_model=GetLayerCombinationsResult
 )

--- a/src/tapir_archicad_mcp/tools/generated/tapir/element_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/element_commands.py
@@ -32,6 +32,8 @@ GetAllElementsParameters,
 GetAllElementsResult,
 GetClassificationsOfElementsParameters,
 GetClassificationsOfElementsResult,
+GetCollisionsParameters,
+GetCollisionsResult,
 GetConnectedElementsParameters,
 GetConnectedElementsResult,
 GetDetailsOfElementsParameters,
@@ -43,6 +45,8 @@ GetGDLParametersOfElementsResult,
 GetSelectedElementsResult,
 GetSubelementsOfHierarchicalElementsParameters,
 GetSubelementsOfHierarchicalElementsResult,
+GetZoneBoundariesParameters,
+GetZoneBoundariesResult,
 HighlightElementsParameters,
 MoveElementsParameters,
 MoveElementsResult,
@@ -506,6 +510,41 @@ register_tool_for_dispatch(
 )
 
 
+def get_collisions(port: int, params: GetCollisionsParameters) -> GetCollisionsResult:
+    """
+    Detect collisions between the given two groups of elements.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="GetCollisions",
+            parameters=params.model_dump(mode='json')
+        )
+        return GetCollisionsResult.model_validate(result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for GetCollisions result: {e}")
+        raise ValueError(f"Received an invalid response from the Archicad API: {e}")
+    except Exception as e:
+        log.error(f"Error executing GetCollisions on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    get_collisions,
+    name="elements_get_collisions",
+    title="GetCollisions",
+    description="Detect collisions between the given two groups of elements.",
+    params_model=GetCollisionsParameters,
+    result_model=GetCollisionsResult
+)
+
+
 def get_connected_elements(port: int, params: GetConnectedElementsParameters) -> GetConnectedElementsResult:
     """
     Gets connected elements of the given elements.
@@ -771,6 +810,41 @@ register_tool_for_dispatch(
     description="Gets the subelements of the given hierarchical elements.",
     params_model=GetSubelementsOfHierarchicalElementsParameters,
     result_model=GetSubelementsOfHierarchicalElementsResult
+)
+
+
+def get_zone_boundaries(port: int, params: GetZoneBoundariesParameters) -> GetZoneBoundariesResult:
+    """
+    Gets the boundaries of the given Zone (connected elements, neighbour zones, etc.).
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="GetZoneBoundaries",
+            parameters=params.model_dump(mode='json')
+        )
+        return GetZoneBoundariesResult.model_validate(result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for GetZoneBoundaries result: {e}")
+        raise ValueError(f"Received an invalid response from the Archicad API: {e}")
+    except Exception as e:
+        log.error(f"Error executing GetZoneBoundaries on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    get_zone_boundaries,
+    name="elements_get_zone_boundaries",
+    title="GetZoneBoundaries",
+    description="Gets the boundaries of the given Zone (connected elements, neighbour zones, etc.).",
+    params_model=GetZoneBoundariesParameters,
+    result_model=GetZoneBoundariesResult
 )
 
 

--- a/src/tapir_archicad_mcp/tools/generated/tapir/favorites_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/favorites_commands.py
@@ -9,7 +9,9 @@ from multiconn_archicad.models.tapir.commands import (
     ApplyFavoritesToElementDefaultsParameters,
 ApplyFavoritesToElementDefaultsResult,
 CreateFavoritesFromElementsParameters,
-CreateFavoritesFromElementsResult
+CreateFavoritesFromElementsResult,
+GetFavoritesByTypeParameters,
+GetFavoritesByTypeResult
 )
 
 
@@ -82,4 +84,39 @@ register_tool_for_dispatch(
     description="Create favorites from the given elements.",
     params_model=CreateFavoritesFromElementsParameters,
     result_model=CreateFavoritesFromElementsResult
+)
+
+
+def get_favorites_by_type(port: int, params: GetFavoritesByTypeParameters) -> GetFavoritesByTypeResult:
+    """
+    Returns a list of the names of all favorites with the given element type
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="GetFavoritesByType",
+            parameters=params.model_dump(mode='json')
+        )
+        return GetFavoritesByTypeResult.model_validate(result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for GetFavoritesByType result: {e}")
+        raise ValueError(f"Received an invalid response from the Archicad API: {e}")
+    except Exception as e:
+        log.error(f"Error executing GetFavoritesByType on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    get_favorites_by_type,
+    name="favorites_get_favorites_by_type",
+    title="GetFavoritesByType",
+    description="Returns a list of the names of all favorites with the given element type",
+    params_model=GetFavoritesByTypeParameters,
+    result_model=GetFavoritesByTypeResult
 )

--- a/src/tapir_archicad_mcp/tools/generated/tapir/library_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/library_commands.py
@@ -6,11 +6,48 @@ from tapir_archicad_mcp.context import multi_conn_instance
 from tapir_archicad_mcp.tools.tool_registry import register_tool_for_dispatch
 
 from multiconn_archicad.models.tapir.commands import (
-    GetLibrariesResult
+    AddFilesToEmbeddedLibraryParameters,
+AddFilesToEmbeddedLibraryResult,
+GetLibrariesResult
 )
 
 
 log = logging.getLogger()
+
+def add_files_to_embedded_library(port: int, params: AddFilesToEmbeddedLibraryParameters) -> AddFilesToEmbeddedLibraryResult:
+    """
+    Adds the given files into the embedded library.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="AddFilesToEmbeddedLibrary",
+            parameters=params.model_dump(mode='json')
+        )
+        return AddFilesToEmbeddedLibraryResult.model_validate(result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for AddFilesToEmbeddedLibrary result: {e}")
+        raise ValueError(f"Received an invalid response from the Archicad API: {e}")
+    except Exception as e:
+        log.error(f"Error executing AddFilesToEmbeddedLibrary on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    add_files_to_embedded_library,
+    name="library_add_files_to_embedded_library",
+    title="AddFilesToEmbeddedLibrary",
+    description="Adds the given files into the embedded library.",
+    params_model=AddFilesToEmbeddedLibraryParameters,
+    result_model=AddFilesToEmbeddedLibraryResult
+)
+
 
 def get_libraries(port: int) -> GetLibrariesResult:
     """

--- a/uv.lock
+++ b/uv.lock
@@ -797,16 +797,18 @@ wheels = [
 
 [[package]]
 name = "multiconn-archicad"
-version = "0.4.2"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "archicad" },
     { name = "psutil" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/73/2f0fa6a6ec2366a62e2ec1b10e12b144429b03997acaa76926201ca6ac81/multiconn_archicad-0.4.2.tar.gz", hash = "sha256:d4fcc9675dfaa390435f64b22bea21ba006bc9d3a549a90a3576ed558697e558", size = 62092, upload-time = "2025-09-02T19:55:40.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/16/8b1a5862f92cd09c843c68ea418e289ac0188944de414fde0f402fa3baf0/multiconn_archicad-0.5.1.tar.gz", hash = "sha256:2c2fb252ab40412cdd5869e806ebddb464f8d8aeef7380f6a0e6cdf1faf391b6", size = 84029, upload-time = "2025-11-03T20:21:08.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/04/afa23877e5492f9e38346b217bccdcb88bcc37fba2fbc068d946ef8bf1ad/multiconn_archicad-0.4.2-py3-none-any.whl", hash = "sha256:adb60bbe78a23812bea4765e0510f271949480de3dca57496bf40cc7c7389b70", size = 75543, upload-time = "2025-09-02T19:55:38.917Z" },
+    { url = "https://files.pythonhosted.org/packages/af/24/0fcc89b003605afecd9303737841513b52742a88b351f6b2cba904a7e270/multiconn_archicad-0.5.1-py3-none-any.whl", hash = "sha256:a79c1472a6fcec73344ff6407769aa54c5d427e2d59b432b7f139aec28e2b5ad", size = 115911, upload-time = "2025-11-03T20:21:06.937Z" },
 ]
 
 [[package]]
@@ -1851,7 +1853,7 @@ wheels = [
 
 [[package]]
 name = "tapir-archicad-mcp"
-version = "0.2.5"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "faiss-cpu" },
@@ -1864,7 +1866,7 @@ dependencies = [
 requires-dist = [
     { name = "faiss-cpu", specifier = ">=1.12.0" },
     { name = "fastmcp", specifier = ">=2.10.5" },
-    { name = "multiconn-archicad", specifier = ">=0.4.1" },
+    { name = "multiconn-archicad", specifier = ">=0.5.1" },
     { name = "sentence-transformers", specifier = ">=5.1.0" },
 ]
 


### PR DESCRIPTION
### **Pull Request: feat: Add 7 new Tapir tools and update to Tapir 1.2.4**

This pull request introduces seven new Tapir tools, expanding the capabilities of the package. With this update, the package is now aligned with Tapir version 1.2.4.

Additionally, the `multiconn-archicad` dependency has been bumped to version 0.5.1 to ensure compatibility and access to the latest features. The package version has been updated to 0.3.1.

**Changes:**
- Added 7 new Tapir tools.
- Updated package to Tapir 1.2.4.
- Bumped `multiconn-archicad` dependency to v0.5.1.
- Bumped version to 0.3.1.