### PR TITLE
fix: add missing BaseModel import for paginated commands

### DIFF
--- a/scripts/generate_tools.py
+++ b/scripts/generate_tools.py
@@ -234,6 +234,7 @@ def generate_tool_files(grouped_commands: dict[str, list[dict]], config: ApiSour
             common_imports.extend([
                 "import time",
                 "from typing import Any",
+                "from pydantic import BaseModel",
                 "from tapir_archicad_mcp.pagination import handle_paginated_request, PAGINATION_CACHE, CACHE_LIFETIME_SECONDS",
             ])
         if REGISTER_AS_MCP_TOOLS:


### PR DESCRIPTION
﻿## Summary
Adds the missing rom pydantic import BaseModel import to generated files that contain paginated commands.

## Problem
The validation.py refactoring (19d9ef5) removed rom pydantic import BaseModel, ConfigDict from the paginated imports block. The ConfigDict removal was intentional (no longer used), but BaseModel is still needed because paginated result models inherit from it:

`python
class PaginatedGetAttributesByTypeResult(BaseModel):  # <-- NameError
`

This causes a NameError: name 'BaseModel' is not defined at import time for any generated file that contains paginated commands (attribute_commands, element_commands, etc.).

## Test plan
- Regenerate tools and verify all 186 tools load without errors
