### PR TITLE
feat: add bearer token auth for HTTP-based transports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "fastmcp>=2.10.5",
     "multiconn-archicad==0.6.5",
     "sentence-transformers>=5.1.0",
+    "uvicorn>=0.35.0",
 ]
 
 [project.urls]

--- a/src/tapir_archicad_mcp/middleware.py
+++ b/src/tapir_archicad_mcp/middleware.py
@@ -1,0 +1,43 @@
+import hmac
+
+
+class BearerTokenMiddleware:
+    """
+    Minimal ASGI middleware that rejects HTTP requests without a valid
+    'Authorization: Bearer <token>' header. Used to protect the HTTP-based
+    transports; stdio does not need it.
+    """
+
+    def __init__(self, app, token: str):
+        self.app = app
+        self.token = token
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        authorization = headers.get(b"authorization", b"").decode("latin-1")
+        expected = f"Bearer {self.token}"
+
+        if not hmac.compare_digest(authorization, expected):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"www-authenticate", b"Bearer"),
+                    ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b'{"error": "Unauthorized: missing or invalid bearer token."}',
+                }
+            )
+            return
+
+        await self.app(scope, receive, send)

--- a/src/tapir_archicad_mcp/server.py
+++ b/src/tapir_archicad_mcp/server.py
@@ -1,12 +1,57 @@
+import hmac
 import logging
 import argparse
 import os
 import sys
 
+import uvicorn
+
 from tapir_archicad_mcp.app import mcp
 from tapir_archicad_mcp.logging_config import setup_logging
 
 setup_logging()
+
+
+class BearerTokenMiddleware:
+    """
+    Minimal ASGI middleware that rejects HTTP requests without a valid
+    'Authorization: Bearer <token>' header. Used to protect the HTTP-based
+    transports; stdio does not need it.
+    """
+
+    def __init__(self, app, token: str):
+        self.app = app
+        self.token = token
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        authorization = headers.get(b"authorization", b"").decode("latin-1")
+        expected = f"Bearer {self.token}"
+
+        if not hmac.compare_digest(authorization, expected):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"www-authenticate", b"Bearer"),
+                    ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b'{"error": "Unauthorized: missing or invalid bearer token."}',
+                }
+            )
+            return
+
+        await self.app(scope, receive, send)
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the Archicad Tapir MCP server.")
@@ -37,6 +82,11 @@ def parse_args() -> argparse.Namespace:
         default=os.getenv("TAPIR_MCP_MOUNT_PATH", None),
         help="Optional mount path for SSE transport.",
     )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("TAPIR_MCP_TOKEN", None),
+        help="Bearer token required for HTTP-based transports. Ignored for stdio.",
+    )
     return parser.parse_args()
 
 def main():
@@ -58,6 +108,14 @@ def main():
         mcp.settings.streamable_http_path = args.streamable_http_path
     if args.mount_path:
         mcp.settings.mount_path = args.mount_path
+
+    if args.token and args.transport != "stdio":
+        app = mcp.sse_app() if args.transport == "sse" else mcp.streamable_http_app()
+        uvicorn.run(BearerTokenMiddleware(app, args.token), host=args.host, port=args.port)
+        return
+
+    if args.token:
+        logging.warning("--token is only used for HTTP-based transports and is ignored for stdio.")
 
     mcp.run(transport=args.transport)
 

--- a/src/tapir_archicad_mcp/server.py
+++ b/src/tapir_archicad_mcp/server.py
@@ -1,4 +1,3 @@
-import hmac
 import logging
 import argparse
 import os
@@ -8,50 +7,9 @@ import uvicorn
 
 from tapir_archicad_mcp.app import mcp
 from tapir_archicad_mcp.logging_config import setup_logging
+from tapir_archicad_mcp.middleware import BearerTokenMiddleware
 
 setup_logging()
-
-
-class BearerTokenMiddleware:
-    """
-    Minimal ASGI middleware that rejects HTTP requests without a valid
-    'Authorization: Bearer <token>' header. Used to protect the HTTP-based
-    transports; stdio does not need it.
-    """
-
-    def __init__(self, app, token: str):
-        self.app = app
-        self.token = token
-
-    async def __call__(self, scope, receive, send):
-        if scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-
-        headers = dict(scope.get("headers", []))
-        authorization = headers.get(b"authorization", b"").decode("latin-1")
-        expected = f"Bearer {self.token}"
-
-        if not hmac.compare_digest(authorization, expected):
-            await send(
-                {
-                    "type": "http.response.start",
-                    "status": 401,
-                    "headers": [
-                        (b"content-type", b"application/json"),
-                        (b"www-authenticate", b"Bearer"),
-                    ],
-                }
-            )
-            await send(
-                {
-                    "type": "http.response.body",
-                    "body": b'{"error": "Unauthorized: missing or invalid bearer token."}',
-                }
-            )
-            return
-
-        await self.app(scope, receive, send)
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the Archicad Tapir MCP server.")

--- a/tests/integration/test_http_auth_live.py
+++ b/tests/integration/test_http_auth_live.py
@@ -1,0 +1,86 @@
+import pytest
+import asyncio
+import socket
+import sys
+import httpx
+import uvicorn
+from unittest.mock import MagicMock
+
+# ==========================================
+# SPEED OPTIMIZATION: Mock search_index in sys.modules
+# before importing app or mcp to prevent heavy ML imports (PyTorch/Faiss) from slowing down test startup
+# ==========================================
+mock_search_index = MagicMock()
+mock_search_index.create_or_load_index = lambda: None
+mock_search_index.search_tools = lambda query: []
+sys.modules["tapir_archicad_mcp.tools.search_index"] = mock_search_index
+
+from tapir_archicad_mcp.app import mcp
+from tapir_archicad_mcp.server import BearerTokenMiddleware
+
+
+def get_free_port() -> int:
+    """Finds an unused ephemeral port dynamically to prevent TCP port collisions."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(autouse=True)
+def mock_heavy_dependencies(monkeypatch):
+    """
+    Automatically mocks out Archicad connections
+    so these tests can run safely on headless runner environments.
+    """
+    fake_multi_conn = MagicMock()
+    fake_multi_conn.active = {}
+    monkeypatch.setattr("tapir_archicad_mcp.app.MultiConn", lambda: fake_multi_conn)
+
+
+@pytest.mark.asyncio
+async def test_live_sse_server_enforces_token():
+    """
+    Launches a real Uvicorn server with BearerTokenMiddleware and verifies
+    that requests are rejected without the token and accepted with it.
+
+    Uses the SSE app because the streamable-http session manager can only
+    be started once per FastMCP instance across the test session.
+    """
+    port = get_free_port()
+    token = "integration-secret"
+
+    if hasattr(mcp, "sse_app"):
+        app = mcp.sse_app()
+    else:
+        from fastmcp.server.http import create_sse_app
+        app = create_sse_app(mcp)
+
+    config = uvicorn.Config(
+        app=BearerTokenMiddleware(app, token),
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+
+    server_task = asyncio.create_task(server.serve())
+    await asyncio.sleep(0.5)
+
+    try:
+        async with httpx.AsyncClient() as client:
+            url = f"http://127.0.0.1:{port}/sse"
+
+            # Without a token the middleware must block the request
+            response = await client.get(url)
+            assert response.status_code == 401
+            assert response.headers.get("www-authenticate") == "Bearer"
+
+            # With the token the request must reach the SSE endpoint
+            async with client.stream(
+                "GET", url, headers={"Authorization": f"Bearer {token}"}
+            ) as response:
+                assert response.status_code == 200
+                assert "text/event-stream" in response.headers.get("content-type", "")
+    finally:
+        server.should_exit = True
+        await server_task

--- a/tests/integration/test_http_auth_live.py
+++ b/tests/integration/test_http_auth_live.py
@@ -16,7 +16,7 @@ mock_search_index.search_tools = lambda query: []
 sys.modules["tapir_archicad_mcp.tools.search_index"] = mock_search_index
 
 from tapir_archicad_mcp.app import mcp
-from tapir_archicad_mcp.server import BearerTokenMiddleware
+from tapir_archicad_mcp.middleware import BearerTokenMiddleware
 
 
 def get_free_port() -> int:
@@ -24,6 +24,18 @@ def get_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("", 0))
         return s.getsockname()[1]
+
+
+async def serve_until_started(server: uvicorn.Server) -> asyncio.Task:
+    """
+    Starts a Uvicorn server in the background and returns once it is
+    actually accepting connections, polling server.started instead of
+    sleeping a fixed interval (faster locally, no flaky CI timeouts).
+    """
+    task = asyncio.create_task(server.serve())
+    while not server.started:
+        await asyncio.sleep(0.01)
+    return task
 
 
 @pytest.fixture(autouse=True)
@@ -63,8 +75,7 @@ async def test_live_sse_server_enforces_token():
     )
     server = uvicorn.Server(config)
 
-    server_task = asyncio.create_task(server.serve())
-    await asyncio.sleep(0.5)
+    server_task = await serve_until_started(server)
 
     try:
         async with httpx.AsyncClient() as client:

--- a/tests/unit/test_http_auth.py
+++ b/tests/unit/test_http_auth.py
@@ -12,7 +12,7 @@ mock_search_index.create_or_load_index = lambda: None
 mock_search_index.search_tools = lambda query: []
 sys.modules["tapir_archicad_mcp.tools.search_index"] = mock_search_index
 
-from tapir_archicad_mcp.server import BearerTokenMiddleware
+from tapir_archicad_mcp.middleware import BearerTokenMiddleware
 
 
 async def plain_app(scope, receive, send):

--- a/tests/unit/test_http_auth.py
+++ b/tests/unit/test_http_auth.py
@@ -1,0 +1,164 @@
+import sys
+import pytest
+import httpx
+from unittest.mock import MagicMock
+
+# ==========================================
+# SPEED OPTIMIZATION: Mock search_index in sys.modules
+# to prevent heavy ML imports (PyTorch/Faiss) from slowing down test startup
+# ==========================================
+mock_search_index = MagicMock()
+mock_search_index.create_or_load_index = lambda: None
+mock_search_index.search_tools = lambda query: []
+sys.modules["tapir_archicad_mcp.tools.search_index"] = mock_search_index
+
+from tapir_archicad_mcp.server import BearerTokenMiddleware
+
+
+async def plain_app(scope, receive, send):
+    """Minimal ASGI app that always answers 200 OK."""
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"text/plain")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+def make_client(token: str) -> httpx.AsyncClient:
+    app = BearerTokenMiddleware(plain_app, token)
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+@pytest.mark.asyncio
+async def test_request_without_token_is_rejected():
+    """
+    A request without an Authorization header must be answered with 401
+    and must never reach the wrapped application.
+    """
+    async with make_client("secret") as client:
+        response = await client.get("/mcp")
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+    assert response.text != "ok"
+
+
+@pytest.mark.asyncio
+async def test_request_with_wrong_token_is_rejected():
+    """
+    A request with an invalid bearer token must be answered with 401.
+    """
+    async with make_client("secret") as client:
+        response = await client.get("/mcp", headers={"Authorization": "Bearer wrong"})
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_request_with_valid_token_passes_through():
+    """
+    A request presenting the configured bearer token must reach the
+    wrapped application unchanged.
+    """
+    async with make_client("secret") as client:
+        response = await client.get("/mcp", headers={"Authorization": "Bearer secret"})
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+# ==========================================
+# CLI wiring: --token / TAPIR_MCP_TOKEN
+# ==========================================
+
+@pytest.fixture
+def mock_run_targets(monkeypatch):
+    """
+    Mocks mcp.run and uvicorn.run so main() can be exercised without
+    starting a real server, and replaces the HTTP app factories with
+    a plain sentinel app.
+    """
+    import tapir_archicad_mcp.server as server_module
+    from tapir_archicad_mcp.app import mcp
+
+    mock_mcp_run = MagicMock()
+    mock_uvicorn_run = MagicMock()
+    monkeypatch.setattr(mcp, "run", mock_mcp_run)
+    monkeypatch.setattr(server_module.uvicorn, "run", mock_uvicorn_run)
+    monkeypatch.setattr(mcp, "streamable_http_app", lambda: plain_app)
+    monkeypatch.setattr(mcp, "sse_app", lambda: plain_app)
+    return mock_mcp_run, mock_uvicorn_run
+
+
+def test_http_transport_with_token_wraps_app(monkeypatch, mock_run_targets):
+    """
+    With --token and an HTTP transport, main() must serve the app through
+    BearerTokenMiddleware via uvicorn instead of the unprotected mcp.run.
+    """
+    mock_mcp_run, mock_uvicorn_run = mock_run_targets
+    monkeypatch.delenv("TAPIR_MCP_TOKEN", raising=False)
+    monkeypatch.setattr(
+        sys, "argv",
+        ["server.py", "--transport", "streamable-http", "--token", "secret"],
+    )
+
+    from tapir_archicad_mcp.server import main
+    main()
+
+    mock_mcp_run.assert_not_called()
+    mock_uvicorn_run.assert_called_once()
+    served_app = mock_uvicorn_run.call_args.args[0]
+    assert isinstance(served_app, BearerTokenMiddleware)
+    assert served_app.token == "secret"
+
+
+def test_token_env_fallback(monkeypatch, mock_run_targets):
+    """
+    Without --token, the TAPIR_MCP_TOKEN environment variable must be used.
+    """
+    mock_mcp_run, mock_uvicorn_run = mock_run_targets
+    monkeypatch.setenv("TAPIR_MCP_TOKEN", "env-secret")
+    monkeypatch.setattr(sys, "argv", ["server.py", "--transport", "sse"])
+
+    from tapir_archicad_mcp.server import main
+    main()
+
+    mock_mcp_run.assert_not_called()
+    served_app = mock_uvicorn_run.call_args.args[0]
+    assert isinstance(served_app, BearerTokenMiddleware)
+    assert served_app.token == "env-secret"
+
+
+def test_stdio_transport_ignores_token(monkeypatch, mock_run_targets):
+    """
+    stdio does not go through HTTP, so a configured token must not change
+    the default mcp.run code path.
+    """
+    mock_mcp_run, mock_uvicorn_run = mock_run_targets
+    monkeypatch.setattr(sys, "argv", ["server.py", "--token", "secret"])
+
+    from tapir_archicad_mcp.server import main
+    main()
+
+    mock_mcp_run.assert_called_once_with(transport="stdio")
+    mock_uvicorn_run.assert_not_called()
+
+
+def test_http_transport_without_token_stays_unwrapped(monkeypatch, mock_run_targets):
+    """
+    Without a token the behaviour of PR #13 must be unchanged: mcp.run
+    serves the HTTP transport directly.
+    """
+    mock_mcp_run, mock_uvicorn_run = mock_run_targets
+    monkeypatch.delenv("TAPIR_MCP_TOKEN", raising=False)
+    monkeypatch.setattr(sys, "argv", ["server.py", "--transport", "streamable-http"])
+
+    from tapir_archicad_mcp.server import main
+    main()
+
+    mock_mcp_run.assert_called_once_with(transport="streamable-http")
+    mock_uvicorn_run.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1654,6 +1654,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "multiconn-archicad" },
     { name = "sentence-transformers" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -1669,6 +1670,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.10.5" },
     { name = "multiconn-archicad", specifier = "==0.6.5" },
     { name = "sentence-transformers", specifier = ">=5.1.0" },
+    { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Why

Follow-up to #13: with `--transport streamable-http` or `sse`, anyone who can reach the port can control Archicad. This adds an opt-in bearer token so the HTTP transports can be exposed on a LAN / via Tailscale safely.

## What

- New `--token` CLI flag with `TAPIR_MCP_TOKEN` env fallback (same pattern as the other flags)
- A minimal ASGI middleware (`BearerTokenMiddleware`, stdlib only) rejects requests without `Authorization: Bearer <token>` with 401 + `WWW-Authenticate`; token comparison uses `hmac.compare_digest`
- Without a token everything behaves exactly as before; stdio is unaffected (a configured token just logs a warning there)

## Tests

- 7 unit tests: middleware accept/reject paths and CLI wiring (token flag, env fallback, stdio ignores token, no-token path unchanged)
- 1 live integration test: real uvicorn server, 401 without token, event-stream reachable with token

Full suite passes (15/15 on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)