### PR TITLE
feat: add optional per-call timeout for dispatched tools

### DIFF
--- a/src/tapir_archicad_mcp/tools/custom/functions.py
+++ b/src/tapir_archicad_mcp/tools/custom/functions.py
@@ -1,4 +1,8 @@
+import contextvars
+import functools
 import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from typing import Optional, Any, Dict
 from pydantic import BaseModel, ValidationError
 
@@ -13,6 +17,37 @@ from multiconn_archicad.conn_header import is_header_fully_initialized, ConnHead
 from multiconn_archicad.basic_types import TeamworkProjectID, SoloProjectID
 
 log = logging.getLogger()
+
+_tool_call_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="tapir-tool-call")
+
+
+def _get_tool_timeout_s() -> float:
+    """Reads the per-call timeout from TAPIR_MCP_TOOL_TIMEOUT_S. 0 means disabled."""
+    raw = os.getenv("TAPIR_MCP_TOOL_TIMEOUT_S", "0")
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning(f"Ignoring invalid TAPIR_MCP_TOOL_TIMEOUT_S value: {raw!r}")
+        return 0.0
+
+
+def _call_with_timeout(func, call_args: Dict[str, Any], timeout_s: float, name: str) -> Any:
+    """
+    Runs a tool callable in a worker thread and raises if it does not
+    finish within timeout_s. The context is copied so tools can still
+    read ContextVars like multi_conn_instance.
+    """
+    context = contextvars.copy_context()
+    future = _tool_call_executor.submit(context.run, functools.partial(func, **call_args))
+    try:
+        return future.result(timeout=timeout_s)
+    except FuturesTimeoutError:
+        future.cancel()
+        raise ValueError(
+            f"Tool '{name}' timed out after {timeout_s}s. Archicad may be blocked by a "
+            f"modal dialog or busy with a long-running operation. The command may still "
+            f"finish in Archicad - check before retrying, especially for element creation."
+        )
 
 
 @mcp.tool(
@@ -123,7 +158,11 @@ def archicad_call_tool(name: str, arguments: dict) -> dict:
         call_args['page_token'] = arguments['page_token']
 
     try:
-        result = target_func(**call_args)
+        timeout_s = _get_tool_timeout_s()
+        if timeout_s > 0:
+            result = _call_with_timeout(target_func, call_args, timeout_s, name)
+        else:
+            result = target_func(**call_args)
 
         if result is None:
             return {}

--- a/tests/unit/test_tool_call_timeout.py
+++ b/tests/unit/test_tool_call_timeout.py
@@ -1,0 +1,127 @@
+import sys
+import time
+import pytest
+from unittest.mock import MagicMock
+
+# ==========================================
+# SPEED OPTIMIZATION: Mock search_index in sys.modules
+# to prevent heavy ML imports (PyTorch/Faiss) from slowing down test startup
+# ==========================================
+mock_search_index = MagicMock()
+mock_search_index.create_or_load_index = lambda: None
+mock_search_index.search_tools = lambda query: []
+sys.modules["tapir_archicad_mcp.tools.search_index"] = mock_search_index
+
+from tapir_archicad_mcp.context import multi_conn_instance
+from tapir_archicad_mcp.tools.custom.functions import archicad_call_tool
+from tapir_archicad_mcp.tools.tool_registry import (
+    TOOL_CALLABLE_REGISTRY,
+    register_tool_for_dispatch,
+)
+
+
+@pytest.fixture
+def fake_tool():
+    """
+    Registers a dispatchable fake tool for the duration of a test and
+    removes it from the registry afterwards.
+    """
+    registered = []
+
+    def _register(func, name: str) -> None:
+        register_tool_for_dispatch(
+            func, name=name, title=name, description="test tool"
+        )
+        registered.append(name)
+
+    yield _register
+
+    for name in registered:
+        TOOL_CALLABLE_REGISTRY.pop(name, None)
+
+
+def test_slow_tool_times_out(monkeypatch, fake_tool):
+    """
+    With TAPIR_MCP_TOOL_TIMEOUT_S set, a tool call exceeding the limit
+    must fail with an actionable error instead of blocking forever.
+    """
+    monkeypatch.setenv("TAPIR_MCP_TOOL_TIMEOUT_S", "0.1")
+
+    def slow_tool(port: int):
+        time.sleep(1)
+        return {"done": True}
+
+    fake_tool(slow_tool, "test_slow_tool")
+
+    with pytest.raises(ValueError, match="timed out"):
+        archicad_call_tool("test_slow_tool", {"port": 19723})
+
+
+def test_fast_tool_completes_within_timeout(monkeypatch, fake_tool):
+    """
+    A tool call finishing within the limit must return its result normally.
+    """
+    monkeypatch.setenv("TAPIR_MCP_TOOL_TIMEOUT_S", "5")
+
+    def fast_tool(port: int):
+        return "done"
+
+    fake_tool(fast_tool, "test_fast_tool")
+
+    result = archicad_call_tool("test_fast_tool", {"port": 19723})
+    assert result == {"result": "done"}
+
+
+def test_timeout_disabled_by_default(monkeypatch, fake_tool):
+    """
+    Without TAPIR_MCP_TOOL_TIMEOUT_S the previous behaviour is unchanged:
+    calls are not raced against a timer.
+    """
+    monkeypatch.delenv("TAPIR_MCP_TOOL_TIMEOUT_S", raising=False)
+
+    def slowish_tool(port: int):
+        time.sleep(0.2)
+        return "done"
+
+    fake_tool(slowish_tool, "test_slowish_tool")
+
+    result = archicad_call_tool("test_slowish_tool", {"port": 19723})
+    assert result == {"result": "done"}
+
+
+def test_context_variables_reach_the_tool(monkeypatch, fake_tool):
+    """
+    Tools read the MultiConn instance from a ContextVar. Running a call
+    under a timeout must not lose that context.
+    """
+    monkeypatch.setenv("TAPIR_MCP_TOOL_TIMEOUT_S", "5")
+    sentinel = object()
+
+    def context_tool(port: int):
+        return multi_conn_instance.get() is sentinel
+
+    fake_tool(context_tool, "test_context_tool")
+
+    token = multi_conn_instance.set(sentinel)
+    try:
+        result = archicad_call_tool("test_context_tool", {"port": 19723})
+    finally:
+        multi_conn_instance.reset(token)
+
+    assert result == {"result": True}
+
+
+def test_invalid_timeout_value_is_ignored(monkeypatch, fake_tool):
+    """
+    A malformed TAPIR_MCP_TOOL_TIMEOUT_S must not break tool execution;
+    the timeout is simply treated as disabled.
+    """
+    monkeypatch.setenv("TAPIR_MCP_TOOL_TIMEOUT_S", "not-a-number")
+
+    def fast_tool(port: int):
+        return "done"
+
+    fake_tool(fast_tool, "test_invalid_timeout_tool")
+
+    result = archicad_call_tool("test_invalid_timeout_tool", {"port": 19723})
+    assert result == {"result": "done"}


### PR DESCRIPTION
## Why

`archicad_call_tool` blocks indefinitely when Archicad cannot answer — e.g. a modal dialog is open or a heavy computation is running (the same failure modes you listed in the #11 discussion). For AI agents this means a hung session with no feedback.

## What

- With `TAPIR_MCP_TOOL_TIMEOUT_S` set (e.g. `30`), dispatched calls run in a worker thread and fail after the limit with an actionable message (modal-dialog hint + warning that the command may still finish in Archicad, so agents don't blindly retry element creation)
- ContextVars (`multi_conn_instance`) are propagated into the worker thread via `contextvars.copy_context()`
- Unset/0 (default): behaviour is exactly as before — no timer, no thread. Deliberately opt-in, since legitimate commands (publishing, large element batches) can take minutes

## Tests

5 unit tests: timeout fires, fast calls unaffected, default off, ContextVar propagation, malformed env value ignored. Full suite passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)