### PR TITLE
fix: resolve tool name collisions between tapir and official commands

### DIFF
--- a/scripts/generator_config.py
+++ b/scripts/generator_config.py
@@ -40,7 +40,10 @@ TAPIR_CONFIG = ApiSourceConfig(
         "GenerateDocumentation", # command only for internal use
         "ShowScriptUI", # used in apps
         "GetScriptUIResult", # used in apps
-        "GetNavigatorItemTree", # no result model in multiconn, so the tool would return None - official command returns the tree
+        "GetNavigatorItemTree", # result model missing from tapir documentation
+        "DeleteAttributes",  # official has a simpler interface for the same functionality (works for MEP systems)
+        "DeleteNavigatorItems",  # same parameters as the Tapir command
+        "MoveNavigatorItem",  # same parameters as the Tapir command
     },
     paginated_commands={
         "GetAllElements": "elements",
@@ -91,9 +94,6 @@ OFFICIAL_CONFIG = ApiSourceConfig(
         "GetProfileAttributes", # Tapir returns index
         "GetSurfaceAttributes", # Tapir returns index
         "GetZoneCategoryAttributes", # Tapir returns index
-        "DeleteAttributes", # Tapir command takes attribute type and index or name, not only ids
-        "DeleteNavigatorItems", # same parameters as the Tapir command
-        "MoveNavigatorItem", # same parameters as the Tapir command
         "RenameNavigatorItem", # Tapir command takes flat parameters instead of a union
     },
     paginated_commands = {

--- a/scripts/generator_config.py
+++ b/scripts/generator_config.py
@@ -31,6 +31,7 @@ TAPIR_CONFIG = ApiSourceConfig(
         "Favorites Commands": "favorites", "Property Commands": "properties", "Attribute Commands": "attributes",
         "Library Commands": "library", "Navigator Commands": "navigator", "Issue Management Commands": "issues",
         "Revision Management Commands": "revisions", "Teamwork Commands": "teamwork", "Developer Commands": "dev",
+        "Solid Element Operation Commands": "elements",
     },
     commands_to_exclude={
         "GetProjectInfo", # discovery_list_active_archicads covers this
@@ -39,6 +40,7 @@ TAPIR_CONFIG = ApiSourceConfig(
         "GenerateDocumentation", # command only for internal use
         "ShowScriptUI", # used in apps
         "GetScriptUIResult", # used in apps
+        "GetNavigatorItemTree", # no result model in multiconn, so the tool would return None - official command returns the tree
     },
     paginated_commands={
         "GetAllElements": "elements",
@@ -89,6 +91,10 @@ OFFICIAL_CONFIG = ApiSourceConfig(
         "GetProfileAttributes", # Tapir returns index
         "GetSurfaceAttributes", # Tapir returns index
         "GetZoneCategoryAttributes", # Tapir returns index
+        "DeleteAttributes", # Tapir command takes attribute type and index or name, not only ids
+        "DeleteNavigatorItems", # same parameters as the Tapir command
+        "MoveNavigatorItem", # same parameters as the Tapir command
+        "RenameNavigatorItem", # Tapir command takes flat parameters instead of a union
     },
     paginated_commands = {
         "GetElementsByClassification": "elements",

--- a/src/tapir_archicad_mcp/tools/generated/official/attribute_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/official/attribute_commands.py
@@ -11,8 +11,6 @@ from multiconn_archicad.models.official.commands import (
 CreateAttributeFoldersResult,
 DeleteAttributeFoldersParameters,
 DeleteAttributeFoldersResult,
-DeleteAttributesParameters,
-DeleteAttributesResult,
 GetActivePenTablesResult,
 GetAttributeFolderStructureParameters,
 GetAttributeFolderStructureResult,
@@ -97,41 +95,6 @@ register_tool_for_dispatch(
     description="Deletes attribute folders and all the deletable attributes and folders it contains. To delete a folder, its identifier has to be provided.",
     params_model=DeleteAttributeFoldersParameters,
     result_model=DeleteAttributeFoldersResult
-)
-
-
-def delete_attributes(port: int, params: DeleteAttributesParameters) -> DeleteAttributesResult:
-    """
-    Deletes attributes.
-    """
-    multi_conn = multi_conn_instance.get()
-    target_port = Port(port)
-    if target_port not in multi_conn.active:
-        raise ValueError(f"Port {port} is not an active Archicad connection.")
-    conn_header = multi_conn.active[target_port]
-    try:
-
-        result_dict = conn_header.core.post_command(
-            command="API.DeleteAttributes",
-            parameters=params.model_dump(mode='json')
-        )
-        return validate_result(DeleteAttributesResult, result_dict)
-
-    except ValidationError as e:
-        log.error(f"Validation error for DeleteAttributes result: {e}")
-        raise ValueError(extract_archicad_errors(e, "DeleteAttributes"))
-    except Exception as e:
-        log.error(f"Error executing DeleteAttributes on port {port}: {e}")
-        raise e
-
-
-register_tool_for_dispatch(
-    delete_attributes,
-    name="attributes_delete_attributes",
-    title="DeleteAttributes",
-    description="Deletes attributes.",
-    params_model=DeleteAttributesParameters,
-    result_model=DeleteAttributesResult
 )
 
 

--- a/src/tapir_archicad_mcp/tools/generated/official/navigator_tree_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/official/navigator_tree_commands.py
@@ -7,9 +7,7 @@ from tapir_archicad_mcp.tools.tool_registry import register_tool_for_dispatch
 from tapir_archicad_mcp.tools.validation import validate_result, extract_archicad_errors
 
 from multiconn_archicad.models.official.commands import (
-    DeleteNavigatorItemsParameters,
-DeleteNavigatorItemsResult,
-GetBuiltInContainerNavigatorItemsParameters,
+    GetBuiltInContainerNavigatorItemsParameters,
 GetBuiltInContainerNavigatorItemsResult,
 GetDetailNavigatorItemsParameters,
 GetDetailNavigatorItemsResult,
@@ -29,48 +27,11 @@ GetSectionNavigatorItemsResult,
 GetStoryNavigatorItemsParameters,
 GetStoryNavigatorItemsResult,
 GetWorksheetNavigatorItemsParameters,
-GetWorksheetNavigatorItemsResult,
-MoveNavigatorItemParameters,
-RenameNavigatorItemParameters
+GetWorksheetNavigatorItemsResult
 )
 
 
 log = logging.getLogger()
-
-def delete_navigator_items(port: int, params: DeleteNavigatorItemsParameters) -> DeleteNavigatorItemsResult:
-    """
-    Deletes items from navigator tree.
-    """
-    multi_conn = multi_conn_instance.get()
-    target_port = Port(port)
-    if target_port not in multi_conn.active:
-        raise ValueError(f"Port {port} is not an active Archicad connection.")
-    conn_header = multi_conn.active[target_port]
-    try:
-
-        result_dict = conn_header.core.post_command(
-            command="API.DeleteNavigatorItems",
-            parameters=params.model_dump(mode='json')
-        )
-        return validate_result(DeleteNavigatorItemsResult, result_dict)
-
-    except ValidationError as e:
-        log.error(f"Validation error for DeleteNavigatorItems result: {e}")
-        raise ValueError(extract_archicad_errors(e, "DeleteNavigatorItems"))
-    except Exception as e:
-        log.error(f"Error executing DeleteNavigatorItems on port {port}: {e}")
-        raise e
-
-
-register_tool_for_dispatch(
-    delete_navigator_items,
-    name="navigator_delete_navigator_items",
-    title="DeleteNavigatorItems",
-    description="Deletes items from navigator tree.",
-    params_model=DeleteNavigatorItemsParameters,
-    result_model=DeleteNavigatorItemsResult
-)
-
 
 def get_built_in_container_navigator_items(port: int, params: GetBuiltInContainerNavigatorItemsParameters) -> GetBuiltInContainerNavigatorItemsResult:
     """
@@ -454,74 +415,4 @@ register_tool_for_dispatch(
     description="Returns the details of the worksheet navigator items identified by their Ids.",
     params_model=GetWorksheetNavigatorItemsParameters,
     result_model=GetWorksheetNavigatorItemsResult
-)
-
-
-def move_navigator_item(port: int, params: MoveNavigatorItemParameters) -> None:
-    """
-    Moves the given navigator item under the <i>parentNavigatorItemId</i> in the navigator tree. If <i>previousNavigatorItemId</i> is not given then inserts it at the first place under the new parent. If it is given then inserts it after this navigator item.
-    """
-    multi_conn = multi_conn_instance.get()
-    target_port = Port(port)
-    if target_port not in multi_conn.active:
-        raise ValueError(f"Port {port} is not an active Archicad connection.")
-    conn_header = multi_conn.active[target_port]
-    try:
-
-        conn_header.core.post_command(
-            command="API.MoveNavigatorItem",
-            parameters=params.model_dump(mode='json')
-        )
-        return None
-
-    except ValidationError as e:
-        log.error(f"Validation error for MoveNavigatorItem result: {e}")
-        raise ValueError(extract_archicad_errors(e, "MoveNavigatorItem"))
-    except Exception as e:
-        log.error(f"Error executing MoveNavigatorItem on port {port}: {e}")
-        raise e
-
-
-register_tool_for_dispatch(
-    move_navigator_item,
-    name="navigator_move_navigator_item",
-    title="MoveNavigatorItem",
-    description="Moves the given navigator item under the <i>parentNavigatorItemId</i> in the navigator tree. If <i>previousNavigatorItemId</i> is not given then inserts it at the first place under the new parent. If it is given then inserts it after this navigator item.",
-    params_model=MoveNavigatorItemParameters,
-    result_model=None
-)
-
-
-def rename_navigator_item(port: int, params: RenameNavigatorItemParameters) -> None:
-    """
-    Renames an existing navigator item by specifying either the name or the ID, or both.
-    """
-    multi_conn = multi_conn_instance.get()
-    target_port = Port(port)
-    if target_port not in multi_conn.active:
-        raise ValueError(f"Port {port} is not an active Archicad connection.")
-    conn_header = multi_conn.active[target_port]
-    try:
-
-        conn_header.core.post_command(
-            command="API.RenameNavigatorItem",
-            parameters=params.model_dump(mode='json')
-        )
-        return None
-
-    except ValidationError as e:
-        log.error(f"Validation error for RenameNavigatorItem result: {e}")
-        raise ValueError(extract_archicad_errors(e, "RenameNavigatorItem"))
-    except Exception as e:
-        log.error(f"Error executing RenameNavigatorItem on port {port}: {e}")
-        raise e
-
-
-register_tool_for_dispatch(
-    rename_navigator_item,
-    name="navigator_rename_navigator_item",
-    title="RenameNavigatorItem",
-    description="Renames an existing navigator item by specifying either the name or the ID, or both.",
-    params_model=RenameNavigatorItemParameters,
-    result_model=None
 )

--- a/src/tapir_archicad_mcp/tools/generated/tapir/navigator_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/navigator_commands.py
@@ -35,7 +35,6 @@ GetLayoutCustomSchemeResult,
 GetLayoutSettingsParameters,
 GetLayoutSettingsResult,
 GetModelViewOptionsResult,
-GetNavigatorItemTreeParameters,
 GetView2DTransformationsParameters,
 GetView2DTransformationsResult,
 GetViewSettingsParameters,
@@ -582,41 +581,6 @@ register_tool_for_dispatch(
     description="Gets all model view options",
     params_model=None,
     result_model=GetModelViewOptionsResult
-)
-
-
-def get_navigator_item_tree(port: int, params: GetNavigatorItemTreeParameters) -> None:
-    """
-    Returns the full navigator item tree for the specified map.
-    """
-    multi_conn = multi_conn_instance.get()
-    target_port = Port(port)
-    if target_port not in multi_conn.active:
-        raise ValueError(f"Port {port} is not an active Archicad connection.")
-    conn_header = multi_conn.active[target_port]
-    try:
-
-        conn_header.core.post_tapir_command(
-            command="GetNavigatorItemTree",
-            parameters=params.model_dump(mode='json')
-        )
-        return None
-
-    except ValidationError as e:
-        log.error(f"Validation error for GetNavigatorItemTree result: {e}")
-        raise ValueError(extract_archicad_errors(e, "GetNavigatorItemTree"))
-    except Exception as e:
-        log.error(f"Error executing GetNavigatorItemTree on port {port}: {e}")
-        raise e
-
-
-register_tool_for_dispatch(
-    get_navigator_item_tree,
-    name="navigator_get_navigator_item_tree",
-    title="GetNavigatorItemTree",
-    description="Returns the full navigator item tree for the specified map.",
-    params_model=GetNavigatorItemTreeParameters,
-    result_model=None
 )
 
 

--- a/src/tapir_archicad_mcp/tools/generated/tapir/solid_element_operation_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/solid_element_operation_commands.py
@@ -45,7 +45,7 @@ def create_solid_element_links(port: int, params: CreateSolidElementLinksParamet
 
 register_tool_for_dispatch(
     create_solid_element_links,
-    name="dev_create_solid_element_links",
+    name="elements_create_solid_element_links",
     title="CreateSolidElementLinks",
     description="Creates solid element operation links between target and operator elements.",
     params_model=CreateSolidElementLinksParameters,
@@ -80,7 +80,7 @@ def get_solid_element_links(port: int, params: GetSolidElementLinksParameters) -
 
 register_tool_for_dispatch(
     get_solid_element_links,
-    name="dev_get_solid_element_links",
+    name="elements_get_solid_element_links",
     title="GetSolidElementLinks",
     description="Returns solid element operation links for each queried element, grouped by role (target or operator).",
     params_model=GetSolidElementLinksParameters,
@@ -115,7 +115,7 @@ def remove_solid_element_links(port: int, params: RemoveSolidElementLinksParamet
 
 register_tool_for_dispatch(
     remove_solid_element_links,
-    name="dev_remove_solid_element_links",
+    name="elements_remove_solid_element_links",
     title="RemoveSolidElementLinks",
     description="Removes solid element operation links between target and operator elements.",
     params_model=RemoveSolidElementLinksParameters,

--- a/uv.lock
+++ b/uv.lock
@@ -1055,7 +1055,7 @@ wheels = [
 
 [[package]]
 name = "tapir-archicad-mcp"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Congrats on 0.5.1 — and thanks for taking the multiconn regen; nice to see the ML dependencies gone, the list/schema workflow is a much better fit.

While updating my fork onto it I hit a side effect of the 1.5.5 command set: five Tapir commands snake-case to the same tool names as existing official ones.

## The problem

`DeleteAttributes`, `DeleteNavigatorItems`, `MoveNavigatorItem`, `RenameNavigatorItem` and `GetNavigatorItemTree` now exist on both sides. Since `registration.py` imports `official` after `tapir`, `TOOL_CALLABLE_REGISTRY` is overwritten and the **official implementation wins all five** — the newer Tapir commands are unreachable. The catalog is an append-only list, so both entries survive there:

```
0.5.1:  239 tools registered, 244 catalog entries
```

Those 5 extra entries mean `archicad_list_commands` shows the same command name twice, and `archicad_get_command_schema` returns whichever entry it finds first — so an agent can read the Tapir schema and then have the official implementation execute with it.

## The fix

Excluded the official variants where the Tapir command is at least as capable, following your existing dedup pattern:

| command | reason |
|---|---|
| `DeleteAttributes` | Tapir takes attribute type + index or name, official only ids |
| `DeleteNavigatorItems` | identical parameters |
| `MoveNavigatorItem` | identical parameters |
| `RenameNavigatorItem` | Tapir takes flat parameters instead of a union (it's also the command your `_generate_rename_navigator_item_fix` special case exists for) |

`GetNavigatorItemTree` goes the other way — I excluded the **Tapir** one: multiconn has no `GetNavigatorItemTreeResult`, so the generated tool is `-> None` and discards the tree, while the official command returns it properly. Worth revisiting if that result model ever gets generated (the schema is recursive).

Also mapped the new `Solid Element Operation Commands` group, which was falling back to the `dev_` prefix (`dev_create_solid_element_links` → `elements_create_solid_element_links`). I left the other `dev_` fallbacks alone — those predate 1.5.5 and look intentional.

## After

```
239 tools registered, 239 catalog entries, no duplicates
```

Full suite green (22 passed). The `uv.lock` line is just the project's own version, which was still recording 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
