### PR TITLE
feat: ran generation pipeline against tapir 1.5.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "fastmcp>=2.10.5",
-    "multiconn-archicad==0.6.7",
+    "multiconn-archicad==0.6.8",
     "uvicorn>=0.35.0",
 ]
 

--- a/src/tapir_archicad_mcp/tools/generated/tapir/element_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/element_commands.py
@@ -34,6 +34,8 @@ from multiconn_archicad.models.tapir.commands import (
     GetElementsByTypeResult,
     GetGDLParametersOfElementsParameters,
     GetGDLParametersOfElementsResult,
+    GetRelationsOfElementsParameters,
+    GetRelationsOfElementsResult,
     GetRoomImageParameters,
     GetRoomImageResult,
     GetSelectedElementsResult,
@@ -598,6 +600,41 @@ register_tool_for_dispatch(
     description="Gets all the GDL parameters (name, type, value) of the given elements.",
     params_model=GetGDLParametersOfElementsParameters,
     result_model=PaginatedGetGDLParametersOfElementsResult
+)
+
+
+def get_relations_of_elements(port: int, params: GetRelationsOfElementsParameters) -> GetRelationsOfElementsResult:
+    """
+    Gets the type-specific relations of the given elements: endpoint and reference line connections of walls, beams and beam segments, boundary elements and boundary sections of zones, the zones on the two sides of windows, doors, skylights and curtain wall panels, and the zones connected to roofs and shells. Available from Archicad 26.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="GetRelationsOfElements",
+            parameters=params.model_dump(mode='json')
+        )
+        return validate_result(GetRelationsOfElementsResult, result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for GetRelationsOfElements result: {e}")
+        raise ValueError(extract_archicad_errors(e, "GetRelationsOfElements"))
+    except Exception as e:
+        log.error(f"Error executing GetRelationsOfElements on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    get_relations_of_elements,
+    name="elements_get_relations_of_elements",
+    title="GetRelationsOfElements",
+    description="Gets the type-specific relations of the given elements: endpoint and reference line connections of walls, beams and beam segments, boundary elements and boundary sections of zones, the zones on the two sides of windows, doors, skylights and curtain wall panels, and the zones connected to roofs and shells. Available from Archicad 26.",
+    params_model=GetRelationsOfElementsParameters,
+    result_model=GetRelationsOfElementsResult
 )
 
 

--- a/src/tapir_archicad_mcp/tools/generated/tapir/element_modification_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/element_modification_commands.py
@@ -12,10 +12,14 @@ from multiconn_archicad.models.tapir.commands import (
     ModifyColumnsResult,
     ModifyDoorsParameters,
     ModifyDoorsResult,
+    ModifyLampsParameters,
+    ModifyLampsResult,
     ModifyMeshesParameters,
     ModifyMeshesResult,
     ModifyMorphsParameters,
     ModifyMorphsResult,
+    ModifyObjectsParameters,
+    ModifyObjectsResult,
     ModifyRoofsParameters,
     ModifyRoofsResult,
     ModifySlabsParameters,
@@ -133,6 +137,41 @@ register_tool_for_dispatch(
 )
 
 
+def modify_lamps(port: int, params: ModifyLampsParameters) -> ModifyLampsResult:
+    """
+    Modifies Lamp elements based on the given parameters.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="ModifyLamps",
+            parameters=params.model_dump(mode='json')
+        )
+        return validate_result(ModifyLampsResult, result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for ModifyLamps result: {e}")
+        raise ValueError(extract_archicad_errors(e, "ModifyLamps"))
+    except Exception as e:
+        log.error(f"Error executing ModifyLamps on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    modify_lamps,
+    name="elements_modify_lamps",
+    title="ModifyLamps",
+    description="Modifies Lamp elements based on the given parameters.",
+    params_model=ModifyLampsParameters,
+    result_model=ModifyLampsResult
+)
+
+
 def modify_meshes(port: int, params: ModifyMeshesParameters) -> ModifyMeshesResult:
     """
     Modifies the attributes of Mesh elements based on the given parameters.
@@ -200,6 +239,41 @@ register_tool_for_dispatch(
     description="Modifies Morph elements based on the given parameters.",
     params_model=ModifyMorphsParameters,
     result_model=ModifyMorphsResult
+)
+
+
+def modify_objects(port: int, params: ModifyObjectsParameters) -> ModifyObjectsResult:
+    """
+    Modifies Object elements based on the given parameters.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="ModifyObjects",
+            parameters=params.model_dump(mode='json')
+        )
+        return validate_result(ModifyObjectsResult, result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for ModifyObjects result: {e}")
+        raise ValueError(extract_archicad_errors(e, "ModifyObjects"))
+    except Exception as e:
+        log.error(f"Error executing ModifyObjects on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    modify_objects,
+    name="elements_modify_objects",
+    title="ModifyObjects",
+    description="Modifies Object elements based on the given parameters.",
+    params_model=ModifyObjectsParameters,
+    result_model=ModifyObjectsResult
 )
 
 

--- a/src/tapir_archicad_mcp/tools/generated/tapir/mep_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/mep_commands.py
@@ -21,6 +21,8 @@ from multiconn_archicad.models.tapir.commands import (
     GetMEPElementsResult,
     GetMEPPortsParameters,
     GetMEPPortsResult,
+    GetMEPPreferenceTablesParameters,
+    GetMEPPreferenceTablesResult,
     GetMEPRoutingElementsParameters,
     GetMEPRoutingElementsResult,
     ModifyMEPRoutingElementsParameters,
@@ -265,6 +267,41 @@ register_tool_for_dispatch(
     description="Retrieves the ports of the given MEP elements including position, shape, size and connection status. Available from Archicad 28.",
     params_model=GetMEPPortsParameters,
     result_model=GetMEPPortsResult
+)
+
+
+def get_mep_preference_tables(port: int, params: GetMEPPreferenceTablesParameters) -> GetMEPPreferenceTablesResult:
+    """
+    Gets the circular cross section preference tables (referenceId, diameter, description) of the Piping or Ventilation domain. Available from Archicad 28.
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="GetMEPPreferenceTables",
+            parameters=params.model_dump(mode='json')
+        )
+        return validate_result(GetMEPPreferenceTablesResult, result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for GetMEPPreferenceTables result: {e}")
+        raise ValueError(extract_archicad_errors(e, "GetMEPPreferenceTables"))
+    except Exception as e:
+        log.error(f"Error executing GetMEPPreferenceTables on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    get_mep_preference_tables,
+    name="mep_get_mep_preference_tables",
+    title="GetMEPPreferenceTables",
+    description="Gets the circular cross section preference tables (referenceId, diameter, description) of the Piping or Ventilation domain. Available from Archicad 28.",
+    params_model=GetMEPPreferenceTablesParameters,
+    result_model=GetMEPPreferenceTablesResult
 )
 
 

--- a/src/tapir_archicad_mcp/tools/generated/tapir/navigator_commands.py
+++ b/src/tapir_archicad_mcp/tools/generated/tapir/navigator_commands.py
@@ -6,6 +6,8 @@ from tapir_archicad_mcp.context import multi_conn_instance
 from tapir_archicad_mcp.tools.tool_registry import register_tool_for_dispatch
 from tapir_archicad_mcp.tools.validation import validate_result, extract_archicad_errors
 from multiconn_archicad.models.tapir.commands import (
+    ChangeDrawingLinkParameters,
+    ChangeDrawingLinkResult,
     CloneProjectMapItemToViewMapParameters,
     CloneProjectMapItemToViewMapResult,
     CreateDetailsParameters,
@@ -52,6 +54,41 @@ from multiconn_archicad.models.tapir.commands import (
 )
 
 log = logging.getLogger()
+
+def change_drawing_link(port: int, params: ChangeDrawingLinkParameters) -> ChangeDrawingLinkResult:
+    """
+    Relinks a Drawing to a different source navigator item. Archicad has no in-place relink API, so this recreates the Drawing against the new source and deletes the original - the returned elementId is a NEW guid, not the input one. The Drawing Title marker's own position is not preserved (undocumented Archicad limitation).
+    """
+    multi_conn = multi_conn_instance.get()
+    target_port = Port(port)
+    if target_port not in multi_conn.active:
+        raise ValueError(f"Port {port} is not an active Archicad connection.")
+    conn_header = multi_conn.active[target_port]
+    try:
+
+        result_dict = conn_header.core.post_tapir_command(
+            command="ChangeDrawingLink",
+            parameters=params.model_dump(mode='json')
+        )
+        return validate_result(ChangeDrawingLinkResult, result_dict)
+
+    except ValidationError as e:
+        log.error(f"Validation error for ChangeDrawingLink result: {e}")
+        raise ValueError(extract_archicad_errors(e, "ChangeDrawingLink"))
+    except Exception as e:
+        log.error(f"Error executing ChangeDrawingLink on port {port}: {e}")
+        raise e
+
+
+register_tool_for_dispatch(
+    change_drawing_link,
+    name="navigator_change_drawing_link",
+    title="ChangeDrawingLink",
+    description="Relinks a Drawing to a different source navigator item. Archicad has no in-place relink API, so this recreates the Drawing against the new source and deletes the original - the returned elementId is a NEW guid, not the input one. The Drawing Title marker's own position is not preserved (undocumented Archicad limitation).",
+    params_model=ChangeDrawingLinkParameters,
+    result_model=ChangeDrawingLinkResult
+)
+
 
 def clone_project_map_item_to_view_map(port: int, params: CloneProjectMapItemToViewMapParameters) -> CloneProjectMapItemToViewMapResult:
     """

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "multiconn-archicad"
-version = "0.6.7"
+version = "0.6.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "archicad" },
@@ -556,9 +556,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/77/b50f0dfa36d4a02caf5f082c48a5fa0b0dfbadb07c4965e30c789ea7e1f1/multiconn_archicad-0.6.7.tar.gz", hash = "sha256:b64fbbf95750a8fdd6692a08f84808d9823624dce4791a02536e2d7225a9f364", size = 160780, upload-time = "2026-08-13T21:09:07.231Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/f8/b935179cfdd2fc9be4ad09a5c33daf0238bd638504ba10905cb44f364293/multiconn_archicad-0.6.8.tar.gz", hash = "sha256:629b77ba77374ed08aebdb0767486857f7555f071f30b30afd2af6573342bc56", size = 166535, upload-time = "2026-08-17T19:51:40.103Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/4d/f46fc9e07a976acf9ef259fa32525fee4a752d42ad8c91a4b091d5fef801/multiconn_archicad-0.6.7-py3-none-any.whl", hash = "sha256:613bad0915b7120458a91cf3494cacd875f864bd3271190a4dffbedb38e87df4", size = 200962, upload-time = "2026-08-13T21:09:08.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/2b/2bb20c5317cdf488e750ba169753fb4a1c6bff1d75ababfb5d351770d559/multiconn_archicad-0.6.8-py3-none-any.whl", hash = "sha256:35bc601eed1b1c2597da50fdcf8cade4751aaf15c9ec0563de32d013cc135b88", size = 206603, upload-time = "2026-08-17T19:51:41.744Z" },
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ wheels = [
 
 [[package]]
 name = "tapir-archicad-mcp"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1073,7 +1073,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.10.5" },
-    { name = "multiconn-archicad", specifier = "==0.6.7" },
+    { name = "multiconn-archicad", specifier = "==0.6.8" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 


### PR DESCRIPTION
### Ran generation pipeline against tapir 1.5.7 / multiconn-archicad to 0.6.8

This update bumps the `multiconn-archicad` dependency to version `0.6.8` and adds 5 new MCP tools covering element modifications, element relations, MEP preference tables, and drawing relinking.

### New MCP Tools Summary

*   **Element Modification & Relations**
    *   `elements_get_relations_of_elements` (`get_relations_of_elements`): Retrieves type-specific relations for elements, including wall/beam connections, zone boundaries, and connected roofs or shells.
    *   `elements_modify_lamps` (`modify_lamps`): Modifies Lamp elements based on input parameters.
    *   `elements_modify_objects` (`modify_objects`): Modifies Object elements based on input parameters.
*   **MEP Tools**
    *   `mep_get_mep_preference_tables` (`get_mep_preference_tables`): Retrieves circular cross-section preference tables (reference ID, diameter, description) for Piping and Ventilation domains.
*   **Navigator Tools**
    *   `navigator_change_drawing_link` (`change_drawing_link`): Relinks a Drawing element to a different source navigator viewpoint.
